### PR TITLE
Add Windows bootstrap script for WSL and Windows apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ For shortlived one-shot configurations, use:
 ```sh
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --one-shot $GITHUB_USERNAME
 ```
+
+## Windows
+
+On a fresh Windows host, run the bootstrap script from an elevated PowerShell
+prompt to install WSL and the Windows-side apps (PowerToys, kanata, GlazeWM,
+Obsidian):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\windows-install.ps1
+```
+
+Then bootstrap the dotfiles from inside WSL using the command above.

--- a/windows-install.ps1
+++ b/windows-install.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+    Bootstraps a fresh Windows host.
+
+.DESCRIPTION
+    Installs WSL and the Windows-side applications used alongside these
+    dotfiles:
+
+        - WSL2 (with the default Ubuntu distribution)
+        - PowerToys
+        - kanata      (keyboard remapper)
+        - GlazeWM     (tiling window manager)
+        - Obsidian
+
+    The Linux/WSL side of the setup is managed by chezmoi; run this script
+    on the Windows host first, then bootstrap the dotfiles from inside WSL:
+
+        sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply <github-username>
+
+.NOTES
+    Run from an elevated PowerShell prompt:
+
+        powershell -ExecutionPolicy Bypass -File .\windows-install.ps1
+
+    The script is idempotent: apps already present are skipped.
+#>
+
+[CmdletBinding()]
+param(
+    # Skip the `wsl --install` step (e.g. WSL is already configured).
+    [switch]$SkipWsl
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-Administrator {
+    $identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Install-WingetApp {
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    # `winget list` exits non-zero when the package is not found.
+    winget list --id $Id --exact --accept-source-agreements *> $null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  [skip] $Name is already installed." -ForegroundColor DarkGray
+        return
+    }
+
+    Write-Host "  [install] $Name ($Id)..." -ForegroundColor Cyan
+    winget install --id $Id --exact --silent `
+        --accept-package-agreements --accept-source-agreements
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to install $Name ($Id). winget exit code: $LASTEXITCODE"
+    }
+}
+
+# --- Preflight ------------------------------------------------------------
+
+if (-not $IsWindows -and $PSVersionTable.PSVersion.Major -ge 6) {
+    throw "This script must be run on Windows."
+}
+
+if (-not (Test-Administrator)) {
+    throw "This script must be run from an elevated (Administrator) PowerShell prompt."
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    throw "winget was not found. Install 'App Installer' from the Microsoft Store, then re-run."
+}
+
+# --- WSL ------------------------------------------------------------------
+
+if ($SkipWsl) {
+    Write-Host "Skipping WSL install (-SkipWsl)." -ForegroundColor DarkGray
+}
+else {
+    Write-Host "Installing WSL..." -ForegroundColor Green
+    # `wsl --install` enables the required features and installs the default
+    # Ubuntu distribution. A reboot may be required to finish the setup.
+    wsl --install
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "wsl --install returned exit code $LASTEXITCODE. A reboot may be required; re-run afterwards if needed."
+    }
+}
+
+# --- Windows applications -------------------------------------------------
+
+Write-Host "Installing Windows applications..." -ForegroundColor Green
+
+$apps = [ordered]@{
+    'Microsoft.PowerToys' = 'PowerToys'
+    'jtroo.kanata'        = 'kanata'
+    'glzr-io.glazewm'     = 'GlazeWM'
+    'Obsidian.Obsidian'   = 'Obsidian'
+}
+
+foreach ($id in $apps.Keys) {
+    Install-WingetApp -Id $id -Name $apps[$id]
+}
+
+Write-Host ""
+Write-Host "Done. If WSL was just installed, reboot and then bootstrap the dotfiles from inside WSL." -ForegroundColor Green


### PR DESCRIPTION
## Summary

Add a PowerShell bootstrap script to automate initial setup on fresh Windows hosts, installing WSL2 and essential Windows-side applications that complement the dotfiles.

## Changes

- **windows-install.ps1**: New idempotent bootstrap script that:
  - Validates prerequisites (elevated PowerShell, winget availability)
  - Installs WSL2 with default Ubuntu distribution (skippable via `-SkipWsl` flag)
  - Installs Windows applications via winget: PowerToys, kanata, GlazeWM, Obsidian
  - Skips already-installed packages for idempotency
  - Provides clear guidance on next steps (reboot if needed, then bootstrap dotfiles from WSL)

- **README.md**: Added Windows setup section documenting:
  - How to run the bootstrap script from elevated PowerShell
  - Which applications are installed
  - Instructions to bootstrap dotfiles from inside WSL after Windows setup completes

## Implementation Details

The script follows PowerShell best practices:
- Strict mode and explicit error handling
- Administrator privilege check with helpful error message
- Helper function `Install-WingetApp` for consistent package installation with skip logic
- Comprehensive inline documentation (synopsis, description, notes)
- Graceful handling of WSL installation warnings (reboot may be required)

This enables the documented two-stage setup flow: Windows bootstrap first, then chezmoi dotfiles initialization from within WSL.

https://claude.ai/code/session_015shYMg4ANDspLDJ5uz9TJS