### PR TITLE
Handle missing 1Password gracefully on ephemeral installs

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -30,6 +30,26 @@
 {{-   end -}}
 {{- end -}}
 
+{{- /* Only touch 1Password when op.exe is actually on PATH. This lets a    */ -}}
+{{- /* secretless one-shot / ephemeral install finish `apply` cleanly on a   */ -}}
+{{- /* machine where Windows 1Password isn't wired up yet; a later apply      */ -}}
+{{- /* (once op.exe is signed in) fills the secrets in automatically.         */ -}}
+{{- /* We invoke op.exe directly via `output` rather than onepasswordRead:    */ -}}
+{{- /* while rendering this config template chezmoi hasn't applied the        */ -}}
+{{- /* [onepassword] command setting yet, so onepasswordRead would call bare  */ -}}
+{{- /* `op` (absent on WSL) instead of the op.exe we just probed for.         */ -}}
+{{- $op := false -}}
+{{- if lookPath "op.exe" -}}{{- $op = true -}}{{- end -}}
+
+{{- $gitEmail := "" -}}
+{{- $sshPublicKeyValue := "" -}}
+{{- $patValue := "" -}}
+{{- if $op -}}
+{{-   $gitEmail = output "op.exe" "read" (printf "op://%s/github/email" $op_vault) | trim -}}
+{{-   $sshPublicKeyValue = output "op.exe" "read" $ssh_public_key | trim -}}
+{{-   $patValue = output "op.exe" "read" $personal_access_token | trim -}}
+{{- end -}}
+
 [onepassword]
   command = "op.exe"
   defaultVault = {{ $op_vault | quote }}
@@ -42,16 +62,16 @@
   command = "nvim"
 
 [github]
-  token = {{ $personal_access_token | quote }}
+  token = {{ $patValue | quote }}
 
 [data]
   ephemeral = {{ $ephemeral }}
   work = {{ $work }}
-  gitEmail = {{ onepasswordRead (printf "op://%s/github/email" $op_vault) | quote }}
-  sshPublicKey = {{ onepasswordRead $ssh_public_key | quote }}
-  personalAccessToken = {{ onepasswordRead $personal_access_token | quote }}
+  gitEmail = {{ $gitEmail | quote }}
+  sshPublicKey = {{ $sshPublicKeyValue | quote }}
+  personalAccessToken = {{ $patValue | quote }}
   hostname = {{ $hostname | quote }}
   headless = {{ $headless }}
   personal = {{ $personal }}
   osid = {{ $osID | quote }}
-  op = true
+  op = {{ $op }}

--- a/home/private_dot_config/git/config.tmpl
+++ b/home/private_dot_config/git/config.tmpl
@@ -1,22 +1,25 @@
 
 [user]
   name = Remstedt, Alex
+{{- if .gitEmail }}
   email = {{ .gitEmail }}
+{{- end }}
+{{- if .sshPublicKey }}
   signingkey = {{ .sshPublicKey }}
 
 [gpg]
   format = ssh
 
-{{ if .work }}
+{{ if .work -}}
 [gpg "ssh"]
 	program = "/mnt/c/Users/ARem/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe"
-{{ else }}
+{{ else -}}
 [gpg "ssh"]
   program = "/mnt/c/Users/A. Remstedt/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe"
 {{ end }}
-
 [commit]
   gpgsign = true
+{{- end }}
 
 
 {{ if .op }}

--- a/home/private_dot_config/zsh/conf.d/01_env.zsh.tmpl
+++ b/home/private_dot_config/zsh/conf.d/01_env.zsh.tmpl
@@ -15,7 +15,9 @@ export RUFF_CACHE_DIR="${XDG_CACHE_HOME}/ruff"
 export STARSHIP_CACHE="${XDG_CACHE_HOME}/starship"
 
 # Github
+{{- if .personalAccessToken }}
 export GITHUB_TOKEN={{ .personalAccessToken | quote }}
+{{- end }}
 
 # Quarto
 export QUARTO_HOME="${XDG_DATA_HOME}/quarto"


### PR DESCRIPTION
## Summary

Refactor 1Password secret retrieval to gracefully handle machines where `op.exe` is not yet available (e.g., ephemeral/one-shot installs on Windows). Instead of failing when `onepasswordRead` is called during template rendering, probe for `op.exe` availability upfront and conditionally fetch secrets only when the tool is present.

## Key Changes

- **Proactive `op.exe` detection**: Added `lookPath "op.exe"` check at the top of `.chezmoi.toml.tmpl` to determine if 1Password CLI is available before attempting secret reads
- **Conditional secret fetching**: Only invoke `op.exe read` commands when `$op` is true, using direct `output` invocation instead of `onepasswordRead` (which would fail during template rendering before the `[onepassword]` command is configured)
- **Template-safe variable initialization**: Pre-declare `$gitEmail`, `$sshPublicKeyValue`, and `$patValue` as empty strings, populating them only if `op.exe` is found
- **Conditional config blocks**: Wrapped git config sections (email, signing key, gpg settings) and GitHub token export with `{{- if .gitEmail }}` / `{{- if .sshPublicKey }}` guards to skip when secrets are unavailable
- **Data field updates**: Changed `op` field from hardcoded `true` to `{{ $op }}` to reflect actual availability

## Implementation Details

The key insight is that during `.chezmoi.toml.tmpl` rendering, the `[onepassword]` command hasn't been applied yet, so `onepasswordRead` would invoke bare `op` (not `op.exe`) on WSL, causing failures. By directly calling `op.exe` via `output` after confirming it exists on PATH, we avoid this bootstrap problem.

This allows one-shot/ephemeral installs to complete successfully without 1Password, with secrets automatically populated on a later `chezmoi apply` once `op.exe` is signed in and available.

https://claude.ai/code/session_01XnoB62VADvYuUPcLWo3wPH