### PR TITLE
docs: Add 1Password CLI setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,41 +7,28 @@ First, make sure the 1Password CLI (`op`) is on your `PATH`, since secrets are f
 command -v op >/dev/null 2>&1 || echo "op is not on PATH; install the 1Password CLI first"
 ```
 
-## Installing the 1Password CLI
+## 1Password CLI on WSL
 
-On WSL (Debian/Ubuntu), install `op` from 1Password's apt repository:
+On WSL, don't install a separate Linux `op` — reuse the one from the Windows
+1Password app. In the Windows desktop app enable **Settings → Developer →
+Integrate with 1Password CLI** so `op.exe` can unlock via the app, then expose
+it to WSL as `op`:
 
 ```sh
-# Add the key and repository
-curl -sS https://downloads.1password.com/linux/keys/1password.asc \
-  | sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
-  | sudo tee /etc/apt/sources.list.d/1password.list
-
-# Add the debsig verification policy
-sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/
-curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol \
-  | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol
-sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
-curl -sS https://downloads.1password.com/linux/keys/1password.asc \
-  | sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
-
-# Install
-sudo apt update && sudo apt install 1password-cli
+# op.exe must be on your Windows PATH (winget installs it there by default)
+mkdir -p ~/.local/bin
+ln -sf "$(command -v op.exe)" ~/.local/bin/op
 ```
 
-Verify and sign in:
+Make sure `~/.local/bin` is on your `PATH`, then verify:
 
 ```sh
 op --version
 op signin
 ```
 
-> On WSL you can also drive the CLI through the Windows 1Password desktop app
-> (biometric unlock, no separate WSL sign-in). Enable **Settings → Developer →
-> Integrate with 1Password CLI** in the Windows app. See the
-> [1Password CLI docs](https://developer.1password.com/docs/cli/get-started/)
-> for other platforms.
+See the [1Password CLI docs](https://developer.1password.com/docs/cli/get-started/)
+for other platforms.
 
 Then install in one line by running the following command in your terminal:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,42 @@ First, make sure the 1Password CLI (`op`) is on your `PATH`, since secrets are f
 command -v op >/dev/null 2>&1 || echo "op is not on PATH; install the 1Password CLI first"
 ```
 
+## Installing the 1Password CLI
+
+On WSL (Debian/Ubuntu), install `op` from 1Password's apt repository:
+
+```sh
+# Add the key and repository
+curl -sS https://downloads.1password.com/linux/keys/1password.asc \
+  | sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+  | sudo tee /etc/apt/sources.list.d/1password.list
+
+# Add the debsig verification policy
+sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/
+curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol \
+  | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol
+sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+curl -sS https://downloads.1password.com/linux/keys/1password.asc \
+  | sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+
+# Install
+sudo apt update && sudo apt install 1password-cli
+```
+
+Verify and sign in:
+
+```sh
+op --version
+op signin
+```
+
+> On WSL you can also drive the CLI through the Windows 1Password desktop app
+> (biometric unlock, no separate WSL sign-in). Enable **Settings → Developer →
+> Integrate with 1Password CLI** in the Windows app. See the
+> [1Password CLI docs](https://developer.1password.com/docs/cli/get-started/)
+> for other platforms.
+
 Then install in one line by running the following command in your terminal:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Dofiles
-Dotfiles managed by chezmoi. Install in one line by running the following command in your terminal:
+Dotfiles managed by chezmoi.
+
+First, make sure the 1Password CLI (`op`) is on your `PATH`, since secrets are fetched at apply time:
+
+```sh
+command -v op >/dev/null 2>&1 || echo "op is not on PATH; install the 1Password CLI first"
+```
+
+Then install in one line by running the following command in your terminal:
 
 ```sh
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME


### PR DESCRIPTION
## Summary

Updated the README to include detailed setup instructions for the 1Password CLI (`op`), which is required for secret management in this dotfiles repository. Added platform-specific guidance for WSL users and links to official documentation.

## Changes

- Added prerequisite check for 1Password CLI on PATH before installation
- Added dedicated "1Password CLI on WSL" section with step-by-step instructions for:
  - Enabling CLI integration in the Windows 1Password app
  - Creating a symlink to expose `op.exe` to WSL as `op`
  - Verifying the setup with `op --version` and `op signin`
- Added link to official 1Password CLI documentation for other platforms
- Reorganized the installation command to appear after all prerequisites

## Details

The changes clarify that `op` must be available before running `chezmoi apply`, since the dotfiles use `{{ onepasswordRead }}` template functions to fetch secrets at apply time. The WSL section addresses a common setup scenario where users have 1Password installed on Windows but need to access it from WSL.

https://claude.ai/code/session_01CTxnwTubgAXaPWcqoHSWev