### PR TITLE
Treat `luna` hostname as a personal machine

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -17,7 +17,7 @@
 {{- $chezmoi_token := "op://development/chezmoi/credential" -}}
 
 {{- if not $ephemeral -}}
-{{-   if or (eq $hostname "AREMSTEDT") (eq $hostname "luna") -}}
+{{-   if has $hostname (list "AREMSTEDT" "luna") -}}
 {{-     $personal = true -}}
 {{-   else if eq $hostname "PLT5CD331HC4N" -}}
 {{-     $personal = false -}}

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -17,7 +17,7 @@
 {{- $chezmoi_token := "op://development/chezmoi/credential" -}}
 
 {{- if not $ephemeral -}}
-{{-   if eq $hostname "AREMSTEDT" -}}
+{{-   if or (eq $hostname "AREMSTEDT") (eq $hostname "luna") -}}
 {{-     $personal = true -}}
 {{-   else if eq $hostname "PLT5CD331HC4N" -}}
 {{-     $personal = false -}}


### PR DESCRIPTION
## What

Adds `luna` to the set of hostnames recognized as a **personal** machine in `home/.chezmoi.toml.tmpl`.

Previously only `AREMSTEDT` was detected as personal; any other hostname (including `luna`) fell through to the `else` branch and was treated as ephemeral + headless.

## Change

```diff
-{{-   if eq $hostname "AREMSTEDT" -}}
+{{-   if or (eq $hostname "AREMSTEDT") (eq $hostname "luna") -}}
```

With this, a machine whose hostname is `luna` gets `personal = true`, uses the `development` 1Password vault, and pulls in the personal-only externals (e.g. quarto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9oaU7fcfpXAJzAXLb4PkJ)_