### PR TITLE
Switch nvim config repo to HTTPS URL

### DIFF
--- a/home/.chezmoiexternals/nvim-config.toml.tmpl
+++ b/home/.chezmoiexternals/nvim-config.toml.tmpl
@@ -1,3 +1,3 @@
 [".config/nvim"]
 type = "git-repo"
-url = "git@github.com:AlexRemstedt/nvim.git"
+url = "https://github.com/AlexRemstedt/nvim.git"


### PR DESCRIPTION
## Summary
Updates the Neovim configuration external repository URL from SSH to HTTPS protocol.

## Changes
- Changed nvim config git repository URL from `git@github.com:AlexRemstedt/nvim.git` (SSH) to `https://github.com/AlexRemstedt/nvim.git` (HTTPS)

## Details
This change makes the external tool configuration more portable across different machine environments. HTTPS URLs don't require SSH key setup, which is particularly useful for ephemeral systems or fresh machine setups where SSH keys may not yet be configured. The Neovim configuration will continue to be managed via the external git-repo mechanism defined in `home/.chezmoiexternals/nvim-config.toml.tmpl`.

https://claude.ai/code/session_01Et9eF1w74vVLqGYXFsp5hi