### PR TITLE
Improve fnm installation robustness in Node.js setup script

### DIFF
--- a/home/.chezmoiscripts/run_once_after_install-node.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_install-node.sh.tmpl
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
-if ! fnm -v fnm >/dev/null 2>&1; then
+set -euo pipefail
+
+# fnm installs itself here (respects XDG_DATA_HOME, defaults to ~/.local/share).
+FNM_PATH="${XDG_DATA_HOME:-$HOME/.local/share}/fnm"
+
+if ! command -v fnm >/dev/null 2>&1; then
   curl -fsSL https://fnm.vercel.app/install | bash
-  fnm completions --shell zsh
 fi
+
+# The installer only appends the PATH setup to .zshrc, which isn't sourced in
+# this script's shell. Put fnm on PATH ourselves so the calls below work.
+export PATH="$FNM_PATH:$PATH"
+
+if ! command -v fnm >/dev/null 2>&1; then
+  echo "fnm not found on PATH after install (looked in $FNM_PATH)" >&2
+  exit 1
+fi
+
 fnm install --lts


### PR DESCRIPTION
## Summary
Enhances the Node.js setup script (`run_once_after_install-node.sh.tmpl`) to more reliably detect and configure the `fnm` (Fast Node Manager) installation, with better error handling and PATH management.

## Key Changes
- Added `set -euo pipefail` for stricter bash error handling
- Replaced `fnm -v fnm` with `command -v fnm` for more portable command detection
- Explicitly set `FNM_PATH` variable to match fnm's default installation location (`~/.local/share/fnm`), respecting `XDG_DATA_HOME` if set
- Added fnm to `PATH` in the script's shell environment since the installer only modifies `.zshrc` (which isn't sourced during script execution)
- Added validation check after installation to confirm fnm is accessible on PATH, with helpful error message if not found
- Removed the `fnm completions --shell zsh` call (completion setup is better handled elsewhere, e.g., in zsh config)

## Implementation Details
The key insight is that fnm's installer script only appends PATH setup to `.zshrc`, which isn't sourced in the non-interactive shell context where this setup script runs. By explicitly exporting `FNM_PATH` to `PATH`, subsequent `fnm` commands in the script (like `fnm install --lts`) will work correctly. The validation check ensures the installation succeeded before proceeding with Node.js installation.

https://claude.ai/code/session_01AJETrmNWrw8GFjKBnxvS7s