### PR TITLE
fix(nvim): don't exit non-zero when bob is missing from PATH

### DIFF
--- a/home/.chezmoiscripts/run_once_after_install-nvim.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_install-nvim.sh.tmpl
@@ -1,2 +1,10 @@
-#!/usr/bin/env zsh
-(( $+commands[bob] )) && bob use stable
+#!/usr/bin/env bash
+set -euo pipefail
+
+# bob (the neovim version manager) is downloaded to ~/.local/bin by chezmoi
+# externals, which isn't necessarily on PATH during this apply session.
+export PATH="$HOME/.local/bin:$PATH"
+
+if command -v bob >/dev/null 2>&1; then
+  bob use stable
+fi


### PR DESCRIPTION
## Problem

After the fnm install fix (#31), `chezmoi apply` failed on the next step:

```
chezmoi: .chezmoiscripts/install-nvim.sh: exit status 1
```

The script was:

```zsh
#!/usr/bin/env zsh
(( $+commands[bob] )) && bob use stable
```

`bob` is downloaded to `~/.local/bin/bob` by chezmoi externals, but `~/.local/bin` isn't necessarily on `PATH` during the apply session (that entry is only added once the zsh config is loaded in a fresh shell). So `$+commands[bob]` is `0`, `(( 0 ))` evaluates false with **exit status 1**, and since that `&&` expression was the script's last command, the whole script exited `1` — chezmoi treated it as a failure and neovim never got installed.

## Fix

- Prepend `~/.local/bin` to `PATH` so `bob` is actually found and `bob use stable` runs.
- Use an `if` block so an absent `bob` exits cleanly (`0`) instead of leaking the failed test's exit status.
- Switch the script to bash to match the other `install-*` scripts.

## Testing

- `bash -n` passes on the script.
- Verified against the reported failure: fnm/Node now installs (Node v24.18.0), and this addresses the subsequent `install-nvim.sh: exit status 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJETrmNWrw8GFjKBnxvS7s)_