### PR TITLE
fix(python): install pipx on all machines before using it

### DIFF
--- a/home/.chezmoiscripts/run_once_after_install-python-env.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_install-python-env.sh.tmpl
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 sudo apt update
-sudo apt upgrade
-sudo apt install python3 -y
+sudo apt upgrade -y
+sudo apt install -y python3 pipx
+pipx ensurepath
 
 {{- if eq .chezmoi.hostname "PLT5CD331HC4N" }}
-sudo apt install pipx
-pipx ensurepath
 pipx install poetry
 sudo apt install -y dotnet-sdk-8.0
 poetry self add artifacts-keyring


### PR DESCRIPTION
## Problem

`chezmoi apply` failed on the python-env step on a non-work machine:

```
/tmp/….install-python-env.sh: line 6: pipx: command not found
chezmoi: .chezmoiscripts/install-python-env.sh: exit status 127
```

`pipx` was only `apt install`-ed inside the work-host block:

```
{{- if eq .chezmoi.hostname "PLT5CD331HC4N" }}
sudo apt install pipx
pipx ensurepath
...
{{- end }}

pipx install tldr   # runs on every machine
```

On any host other than `PLT5CD331HC4N`, the whole `if` block is skipped, so pipx is never installed — yet `pipx install tldr` at the end runs unconditionally and dies with exit 127.

## Fix

- Move `sudo apt install pipx` and `pipx ensurepath` out of the work-only block so **every** machine installs pipx before it's used.
- Add `-y` to `apt upgrade` so it can't block on an interactive prompt.
- Add `set -euo pipefail`.

## Testing

- Rendered both template variants (work host and non-work host) and `bash -n` passes on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJETrmNWrw8GFjKBnxvS7s)_