### PR TITLE
fix(scripts): quote variables, fix read, tighten shellcheck gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,8 @@ jobs:
         run: |
           # Lint plain (non-templated) bash scripts. chezmoi *.tmpl files and
           # zsh scripts are skipped: they aren't valid standalone shell and
-          # shellcheck can't parse them. Fail only on error-level findings so
-          # style nits don't block, while real breakage still trips CI.
+          # shellcheck can't parse them. Fail on warning-level findings and
+          # above; low-value info/style nits don't block.
           mapfile -t files < <(
             find home -type f \
               ! -name '*.tmpl' \
@@ -32,4 +32,4 @@ jobs:
             exit 0
           fi
           printf 'Linting:\n'; printf '  %s\n' "${files[@]}"
-          shellcheck --severity=error "${files[@]}"
+          shellcheck --severity=warning "${files[@]}"

--- a/home/private_dot_local/bin/executable_clone-bare-for-worktrees.sh
+++ b/home/private_dot_local/bin/executable_clone-bare-for-worktrees.sh
@@ -12,7 +12,7 @@ url=$1
 basename=${url##*/}
 name=${2:-${basename%.*}}
 
-mkdir $name
+mkdir "$name"
 cd "$name"
 
 # Moves all the administrative git files (a.k.a $GIT_DIR) under .bare directory.

--- a/home/private_dot_local/bin/executable_tmux-cht.sh
+++ b/home/private_dot_local/bin/executable_tmux-cht.sh
@@ -4,7 +4,7 @@ if [[ -z $selected ]]; then
   exit 0
 fi
 
-read -p "Enter Query: " query
+read -rp "Enter Query: " query
 
 if grep -qs "$selected" ~/.tmux-cht-languages; then
   query=$(echo "$query" | tr ' ' '+')

--- a/home/private_dot_local/bin/executable_tmux-windowizer
+++ b/home/private_dot_local/bin/executable_tmux-windowizer
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-branch_name=$(basename $1)
+branch_name=$(basename "$1")
 session_name=$(tmux display-message -p "#S")
-clean_name=$(echo $branch_name | tr "./" "__")
+clean_name=$(echo "$branch_name" | tr "./" "__")
 target="$session_name:$clean_name"
 
-if ! tmux has-session -t $target 2> /dev/null; then
-    tmux neww -dn $clean_name
+if ! tmux has-session -t "$target" 2> /dev/null; then
+    tmux neww -dn "$clean_name"
 fi
 
 shift
-tmux send-keys -t $target "$*"
+tmux send-keys -t "$target" "$*"


### PR DESCRIPTION
Follow-up to #34, addressing the shellcheck findings that the initial `--severity=error` gate was too lenient to catch.

## Changes

- **`tmux-windowizer`**: quote `$1`, `$target`, and `$clean_name` (SC2086). Also strips a stray carriage return that was hiding inside the `send-keys` string and being sent as a literal CR — a real latent bug, not just a lint nit.
- **`clone-bare-for-worktrees`**: quote `mkdir "$name"` (SC2086), so it no longer breaks on paths with spaces.
- **`tmux-cht`**: `read -rp` instead of `read -p` so backslashes in the query aren't mangled (SC2162).
- **CI**: raise the shellcheck gate from `--severity=error` to `--severity=warning`.

## Verification

Ran the exact CI selection + shellcheck locally. The linted scripts are now clean at *every* severity (`warning`, `info`, and `style`), so the gate passes with headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jjBzJPzNweb98gHUHfBe2

---
_Generated by [Claude Code](https://claude.ai/code/session_011jjBzJPzNweb98gHUHfBe2)_