### PR TITLE
fix(secrets): consolidate onto dedicated token, stop leaking secrets to disk and env

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -13,7 +13,9 @@
 {{- $hostname := .chezmoi.hostname -}}
 {{- $op_vault := "development" -}}
 {{- $ssh_public_key := "op://development/personal-machine/public key" -}}
-{{- $personal_access_token := "op://development/personal-machine-pat/credential" -}}
+{{- /* Dedicated fine-grained token (public repos only) used solely to raise */ -}}
+{{- /* the GitHub API rate limit when resolving externals. Lives in the      */ -}}
+{{- /* development vault regardless of machine, matching prior behaviour.     */ -}}
 {{- $chezmoi_token := "op://development/chezmoi/credential" -}}
 
 {{- if not $ephemeral -}}
@@ -24,11 +26,20 @@
 {{-     $work = true -}}
 {{-     $op_vault = "work" -}}
 {{-     $ssh_public_key = "op://work/work-machine/public key" -}}
-{{-     $personal_access_token = "op://work/work-machine-pat/credential" -}}
 {{-   else -}}
 {{-     $ephemeral = true -}}
 {{-     $headless = true -}}
 {{-   end -}}
+{{- end -}}
+
+{{- /* Secrets are only read on non-ephemeral machines, where 1Password (op) */ -}}
+{{- /* is available. Ephemeral/one-shot boxes get empty values and skip op    */ -}}
+{{- /* entirely so `chezmoi init` no longer hard-fails when op is absent.      */ -}}
+{{- $gitEmail := "" -}}
+{{- $sshPublicKey := "" -}}
+{{- if not $ephemeral -}}
+{{-   $gitEmail = onepasswordRead (printf "op://%s/github/email" $op_vault) -}}
+{{-   $sshPublicKey = onepasswordRead $ssh_public_key -}}
 {{- end -}}
 
 [onepassword]
@@ -42,20 +53,20 @@
 [edit]
   command = "nvim"
 
+{{- if not $ephemeral }}
 [github]
-  token = {{ $personal_access_token | quote }}
+  token = {{ onepasswordRead $chezmoi_token | quote }}
+{{- end }}
 
 [data]
   ephemeral = {{ $ephemeral }}
   work = {{ $work }}
-  gitEmail = {{ onepasswordRead (printf "op://%s/github/email" $op_vault) | quote }}
-  sshPublicKey = {{ onepasswordRead $ssh_public_key | quote }}
-  personalAccessToken = {{ onepasswordRead $personal_access_token | quote }}
-  chezmoiToken = {{ onepasswordRead $chezmoi_token | quote }}
+  gitEmail = {{ $gitEmail | quote }}
+  sshPublicKey = {{ $sshPublicKey | quote }}
   hostname = {{ $hostname | quote }}
   headless = {{ $headless }}
   personal = {{ $personal }}
   osid = {{ $osID | quote }}
-  op = true
+  op = {{ not $ephemeral }}
 
 

--- a/home/private_dot_config/git/config.tmpl
+++ b/home/private_dot_config/git/config.tmpl
@@ -1,9 +1,12 @@
 
 [user]
   name = Remstedt, Alex
+{{- if not .ephemeral }}
   email = {{ .gitEmail }}
   signingkey = {{ .sshPublicKey }}
+{{- end }}
 
+{{- if not .ephemeral }}
 [gpg]
   format = ssh
 
@@ -17,6 +20,7 @@
 
 [commit]
   gpgsign = true
+{{- end }}
 
 
 {{ if .op }}

--- a/home/private_dot_config/zsh/dot_zshrc.tmpl
+++ b/home/private_dot_config/zsh/dot_zshrc.tmpl
@@ -3,8 +3,6 @@ fpath=("${(@)fpath:#/usr/share/zsh/vendor-completions}")
 autoload -Uz compinit
 compinit
 
-export CHEZMOI_GITHUB_ACCESS_TOKEN={{ .chezmoiToken | quote }}
-
 # Modular ZSH Configuration
 # Load utility functions first
 source ~/.config/zsh/conf.d/00_utils.zsh


### PR DESCRIPTION
## Problem

Tracing every secret to its consumer surfaced an inversion in the token handling:

| Secret slot | Was | Issue |
|---|---|---|
| `[github] token` | broad `personal-machine-pat` PAT | **higher-privilege** token, written to disk |
| `[data] personalAccessToken` | broad PAT again | **dead** — no template references it; redundant on-disk copy |
| shell `export CHEZMOI_GITHUB_ACCESS_TOKEN` | dedicated `chezmoi` token | **low-privilege** token, but broadcast into every shell's environment |
| `onepasswordRead` calls | unconditional | `chezmoi init --one-shot` on a box without `op` **hard-fails**, contradicting the documented ephemeral flow |

So the broad PAT was the one persisted to disk, while the safe token was the one leaked into the environment — backwards.

## What the token is actually for

`external.toml.tmpl` only uses it to raise the GitHub **API rate limit** when resolving the latest release URLs for the ~20 downloaded tools (unauthenticated is 60/hr, authenticated 5000/hr). It reads public release metadata only, so a fine-grained public-repos-only token is exactly right and near-zero blast radius.

## Changes

- **`.chezmoi.toml.tmpl`**
  - Remove the unused `[data] personalAccessToken` (dead key).
  - Point `[github] token` at the dedicated fine-grained token (`op://development/chezmoi/credential`) instead of the broad PAT.
  - Drop `$personal_access_token` and both `*-machine-pat` op paths entirely — the personal PAT no longer touches this repo.
  - Remove `[data] chezmoiToken` (its only consumer was the shell export).
  - Guard all `onepasswordRead` calls behind `not ephemeral` and gate the whole `[github]` section, so one-shot on a box without `op` no longer fails. Ephemeral machines get empty secrets and `op = false`.
- **`zsh/dot_zshrc.tmpl`**: drop the global `CHEZMOI_GITHUB_ACCESS_TOKEN` export. With the dedicated token now in `[github] token`, chezmoi reads it from config on every apply — the export was a redundant second copy that also polluted every shell's environment.
- **`git/config.tmpl`**: skip `email`/`signingkey`/`gpg`/`gpgsign` on ephemeral machines (where those values are now empty), so git doesn't try to sign with an empty key.

## Net effect

The only GitHub token ever on disk is now the harmless public-only one, in a 0600 config file; nothing sensitive lives in the shell environment; the broad personal PAT is fully removed from the repo (you can revoke it if nothing else uses it); and ephemeral/one-shot works without 1Password.

## Verification

Rendered the config template with stubbed chezmoi functions for **personal**, **work**, and **ephemeral** hostnames and parsed each with Python `tomllib`:
- personal/work → valid TOML, `[github]` present, `op = true`, secrets populated.
- ephemeral → valid TOML, **no `[github]` section**, `op = false`, empty secrets, and `onepasswordRead` is **never called**.

Rendered `git/config.tmpl` for ephemeral and personal/work scenarios and confirmed each parses via `git config --list`: ephemeral emits identity name only (no empty-key signing); personal/work emit full signing config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jjBzJPzNweb98gHUHfBe2

---
_Generated by [Claude Code](https://claude.ai/code/session_011jjBzJPzNweb98gHUHfBe2)_