### PR TITLE
feat(windows): multi-OS groundwork — .chezmoiignore + OS detection

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -10,6 +10,18 @@
 {{-   $osID = printf "%s-%s" .chezmoi.os .chezmoi.osRelease.id -}}
 {{- end -}}
 
+{{- /* OS awareness. WSL reports os == "linux", so it is distinguished from a  */ -}}
+{{- /* native Linux box by the "microsoft"/"WSL" marker in the kernel release. */ -}}
+{{- /* Nothing consumes windows/wsl yet; they are groundwork for per-OS files. */ -}}
+{{- $isWindows := eq .chezmoi.os "windows" -}}
+{{- $isWSL := false -}}
+{{- if and (eq .chezmoi.os "linux") (hasKey .chezmoi "kernel") (hasKey .chezmoi.kernel "osrelease") -}}
+{{-   $kernel := lower .chezmoi.kernel.osrelease -}}
+{{-   if or (contains "microsoft" $kernel) (contains "wsl" $kernel) -}}
+{{-     $isWSL = true -}}
+{{-   end -}}
+{{- end -}}
+
 {{- $hostname := .chezmoi.hostname -}}
 {{- $op_vault := "development" -}}
 {{- $ssh_public_key := "op://development/personal-machine/public key" -}}
@@ -68,5 +80,8 @@
   personal = {{ $personal }}
   osid = {{ $osID | quote }}
   op = {{ not $ephemeral }}
+  os = {{ .chezmoi.os | quote }}
+  windows = {{ $isWindows }}
+  wsl = {{ $isWSL }}
 
 

--- a/home/.chezmoiexternals/external.toml.tmpl
+++ b/home/.chezmoiexternals/external.toml.tmpl
@@ -1,4 +1,6 @@
-{{- if not .ephemeral -}}
+{{- /* Linux-only: every asset below is a Linux binary. Windows gets its own */ -}}
+{{- /* externals in a later pass.                                            */ -}}
+{{- if and (eq .chezmoi.os "linux") (not .ephemeral) -}}
 {{/* $arch:    x86_64 / aarch64 naming (atuin, uv, bob, rustup, eza, ...) */}}
 {{/* $archAlt: x86_64 / arm64 naming   (lazygit, lazydocker)             */}}
 {{-   $arch := .chezmoi.arch -}}

--- a/home/.chezmoiexternals/nvim-config.toml.tmpl
+++ b/home/.chezmoiexternals/nvim-config.toml.tmpl
@@ -1,3 +1,7 @@
+{{- /* Native Windows nvim reads ~/AppData/Local/nvim, not ~/.config/nvim, so */ -}}
+{{- /* clone only on Linux/WSL for now.                                        */ -}}
+{{- if eq .chezmoi.os "linux" }}
 [".config/nvim"]
 type = "git-repo"
 url = "https://github.com/AlexRemstedt/nvim.git"
+{{- end }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -1,0 +1,46 @@
+{{- if eq .chezmoi.os "windows" -}}
+{{- /* Nothing in this repo is Windows-ready yet: the shell layer is zsh, the  */ -}}
+{{- /* externals are Linux binaries, and the app configs live under ~/.config  */ -}}
+{{- /* (XDG) rather than %APPDATA%/%LOCALAPPDATA%. Ignore the whole Linux/WSL   */ -}}
+{{- /* tree so `chezmoi apply` is a safe no-op on native Windows. Entries get   */ -}}
+{{- /* un-ignored as Windows variants land.                                    */ -}}
+
+# Shell (zsh) — no native Windows equivalent yet
+.zshenv
+.config/zsh
+.config/sheldon
+
+# tmux — does not run on native Windows
+.config/tmux
+.config/tmux-sessionizer
+.tmux-cht-command
+.tmux-cht-languages
+
+# XDG desktop integration — Linux only
+.config/mimeapps.list
+
+# App configs placed at ~/.config; native Windows apps read %APPDATA%/%LOCALAPPDATA%.
+# Re-add with Windows-correct target paths in a later pass.
+.config/git
+.config/starship
+.config/lazygit
+.config/jrnl
+.config/nvim
+
+# Unix helper scripts (~/.local/bin) and downloaded Linux binaries (~/.local/...)
+.local
+
+# Setup scripts (bash). Target names are the source filenames with the
+# run_/once_/onchange_/before_/after_ prefixes and .tmpl suffix stripped.
+install_packages.sh
+install-node.sh
+install-nvim.sh
+install-python-env.sh
+install-rust.sh
+jrnl.sh
+chsh.sh
+create_symlinks.sh
+{{- end -}}
+{{- /* On Linux/WSL this file renders empty, so nothing is ignored and behaviour */ -}}
+{{- /* is unchanged. Windows-only source files (added later) should be ignored   */ -}}
+{{- /* here under `{{ if ne .chezmoi.os "windows" }}` when they exist.           */ -}}


### PR DESCRIPTION
Step 1 of expanding the config toward native Windows. This is pure foundation: it makes `chezmoi apply` a **safe no-op on native Windows** and adds the OS-detection groundwork later steps build on — **without changing Linux/WSL behaviour at all.**

## Why

The repo had zero OS-gating (no `.chezmoiignore`, no `windows` branches). On native Windows, `chezmoi apply` would try to deploy the entire zsh/tmux/XDG tree into `~/.config` and then fail trying to run the `.sh` setup scripts with no `sh`. Nothing here was Windows-ready.

## Changes

- **`.chezmoiignore`** *(new, templated)* — on Windows, ignore the whole Linux/WSL tree: zsh, tmux, sheldon, `mimeapps.list`, all of `~/.local`, the `~/.config` app configs, and the bash setup scripts (matched by target name). Renders **empty on Linux/WSL**, so nothing is ignored there.
- **`.chezmoi.toml.tmpl`** — detect the OS and expose `os` / `windows` / `wsl` in `[data]`. WSL reports `os == "linux"`, so it's told apart from native Linux via the `microsoft`/`WSL` marker in the kernel release. Nothing consumes these yet — they're groundwork for per-OS templating (e.g. the `/mnt/c` paths in `git/config.tmpl`, step 3).
- **`external.toml.tmpl`** — gate the (Linux-only) binaries on `os == "linux"` so Windows doesn't try to download them.
- **`nvim-config.toml.tmpl`** — clone only on Linux/WSL (native Windows nvim reads `~/AppData/Local/nvim`, not `~/.config/nvim`).

## Verification

Since chezmoi couldn't be installed through the environment proxy, I rendered every changed template with Go's `text/template` + stubbed chezmoi functions, for **wsl**, **native-linux**, and **windows**:

| | Linux/WSL | Windows |
|---|---|---|
| `.chezmoi.toml.tmpl` | valid TOML, `op` unchanged, `wsl` True only under WSL | valid TOML, `windows=True`, no `[github]` change |
| `.chezmoiignore` | **empty** (0 patterns → nothing ignored) | 22 patterns |
| `external.toml.tmpl` | **18 entries** (unchanged) | 0 entries |
| `nvim-config.toml.tmpl` | present | empty |

So Linux/WSL output is byte-for-byte what it was, plus the three inert `[data]` flags.

## Not in scope (later steps)
PowerShell profile, Windows externals (`*-pc-windows-msvc`), git-config OS-branching for the `/mnt/c` paths, and AppData-vs-`.config` placement for nvim/lazygit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jjBzJPzNweb98gHUHfBe2

---
_Generated by [Claude Code](https://claude.ai/code/session_011jjBzJPzNweb98gHUHfBe2)_