### PR TITLE
feat(mouse): make mouse support a shared system variable

### DIFF
--- a/home/dot_zshenv
+++ b/home/dot_zshenv
@@ -9,3 +9,6 @@ export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 export XDG_PROJECTS_DIR="${XDG_PROJECTS_DIR:-$HOME/Projects}"
 export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 
+# Mouse support toggle, consumed by nvim and tmux; set MOUSE=0 to disable
+export MOUSE="${MOUSE:-1}"
+

--- a/home/private_dot_config/tmux/tmux.conf.tmpl
+++ b/home/private_dot_config/tmux/tmux.conf.tmpl
@@ -10,7 +10,7 @@ set -g window-status-current-style "fg=blue bold"
 set -g status-right "#(date '+%Y-%m-%d %H:%M %Z')"
 set -g status-left "[#S] #{pomodoro_status} "
 set -g status-left-length 200
-set -g mouse on
+if-shell '[ "$MOUSE" = "0" ]' 'set -g mouse off' 'set -g mouse on'
 set escape-time 0
 
 bind h select-pane -L


### PR DESCRIPTION
## Summary
- Export `MOUSE=1` in `.zshenv` as a system-wide default, right alongside the existing `XDG_*` vars, so it's guaranteed to be set before any shell that might launch nvim or tmux.
- Switch `tmux.conf.tmpl` from a hardcoded `set -g mouse on` to `if-shell '[ "$MOUSE" = "0" ]' 'set -g mouse off' 'set -g mouse on'`, mirroring the semantics already implemented in nvim ([AlexRemstedt/nvim#16](https://github.com/AlexRemstedt/nvim/pull/16)): mouse on by default, `MOUSE=0` disables it.
- Result: setting `MOUSE=0` once now disables mouse support consistently in both nvim and tmux; nothing set means both stay on.

Closes #20

## Test plan
- [x] `tmux -f <conf> new-session` with `MOUSE` unset → `mouse on`
- [x] `MOUSE=0 tmux -f <conf> new-session` → `mouse off`
- [x] `MOUSE=1 tmux -f <conf> new-session` → `mouse on`
- [x] Confirmed `dot_zshenv` and `tmux.conf.tmpl` are excluded from the shellcheck CI gate (no shebang / `.tmpl`), so lint is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqUNLZQKMtJtacE5hrXgsN