### PR TITLE
feat(glazewm): add GlazeWM window manager config

### DIFF
--- a/.docs/glazewm/README.md
+++ b/.docs/glazewm/README.md
@@ -1,0 +1,37 @@
+# GlazeWM
+
+[repo](https://github.com/glzr-io/glazewm)
+
+A tiling window manager for Windows, inspired by i3 and Polybar. This is the
+only Windows-only config in the repo, so it is gated to Windows in
+`home/.chezmoiignore` and won't be applied on Linux/WSL.
+
+## Installation
+
+### Scoop
+
+```powershell
+scoop install glazewm
+```
+
+### Winget
+
+```powershell
+winget install glzr-io.glazewm
+```
+
+## Configuration
+
+The config lives at `~/.glzr/glazewm/config.yaml`
+(`home/dot_glzr/glazewm/config.yaml` in this repo). On a fresh Windows machine:
+
+```powershell
+chezmoi init --apply AlexRemstedt/dotfiles
+```
+
+Reload the config after edits with `alt+shift+r` (or `wm-reload-config`).
+
+### Zebar
+
+The `startup_commands` launch [Zebar](https://github.com/glzr-io/zebar) as the
+status bar. It ships with GlazeWM, so no separate install is needed.

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -1,0 +1,4 @@
+# GlazeWM is Windows-only; don't deploy it on Linux/WSL machines.
+{{ if ne .chezmoi.os "windows" }}
+.glzr
+{{ end }}

--- a/home/dot_glzr/glazewm/config.yaml
+++ b/home/dot_glzr/glazewm/config.yaml
@@ -1,0 +1,363 @@
+general:
+  # Commands to run when the WM has started. This is useful for running a
+  # script or launching another application.
+  # Example: The below command launches Zebar.
+  startup_commands: ["shell-exec zebar"]
+
+  # Commands to run just before the WM is shutdown.
+  # Example: The below command kills Zebar.
+  shutdown_commands: ["shell-exec taskkill /IM zebar.exe /F"]
+
+  # Commands to run after the WM config is reloaded.
+  config_reload_commands: []
+
+  # Whether to automatically focus windows underneath the cursor.
+  focus_follows_cursor: true
+
+  # Whether to switch back and forth between the previously focused
+  # workspace when focusing the current workspace.
+  toggle_workspace_on_refocus: false
+
+  cursor_jump:
+    # Whether to automatically move the cursor on the specified trigger.
+    enabled: true
+
+    # Trigger for cursor jump:
+    # - 'monitor_focus': Jump when focus changes between monitors.
+    # - 'window_focus': Jump when focus changes between windows.
+    trigger: "window_focus"
+
+  # How windows should be hidden when switching workspaces.
+  # - 'cloak': Recommended. Hides windows with no animation.
+  # - 'hide': Legacy method (v3.5 and earlier) that has a brief animation,
+  # but has stability issues with some apps.
+  hide_method: "cloak"
+
+  # Affects which windows get shown in the native Windows taskbar. Has no
+  # effect if `hide_method: 'hide'`.
+  # - 'true': Show all windows (regardless of workspace).
+  # - 'false': Only show windows from the currently shown workspaces.
+  show_all_in_taskbar: false
+
+gaps:
+  # Whether to scale the gaps with the DPI of the monitor.
+  scale_with_dpi: true
+
+  # Gap between adjacent windows.
+  inner_gap: "5px"
+
+  # Gap between windows and the screen edge.
+  outer_gap:
+    top: "5px"
+    right: "10px"
+    bottom: "10px"
+    left: "10px"
+
+window_effects:
+  # Visual effects to apply to the focused window.
+  focused_window:
+    border:
+      enabled: true
+      color: "#8dbcff"
+    hide_title_bar:
+      enabled: false
+    corner_style:
+      enabled: false
+      # Allowed values: 'square', 'rounded', 'small_rounded'.
+      style: "rounded"
+    transparency:
+      enabled: false
+      opacity: "95%"
+
+  # Visual effects to apply to non-focused windows.
+  other_windows:
+    border:
+      enabled: true
+      color: "#a1a1a1"
+    hide_title_bar:
+      enabled: false
+    corner_style:
+      enabled: false
+      style: "square"
+    transparency:
+      enabled: true
+      opacity: .95
+
+window_behavior:
+  # New windows are created in this state whenever possible.
+  # Allowed values: 'tiling', 'floating'.
+  initial_state: "tiling"
+
+  # Sets the default options for when a new window is created. This also
+  # changes the defaults for when the state change commands, like
+  # `set-floating`, are used without any flags.
+  state_defaults:
+    floating:
+      # Whether to center floating windows by default.
+      centered: true
+
+      # Whether to show floating windows as always on top.
+      shown_on_top: false
+
+    fullscreen:
+      # Maximize the window if possible. If the window doesn't have a
+      # maximize button, then it'll be fullscreen'ed normally instead.
+      maximized: false
+
+      # Whether to show fullscreen windows as always on top.
+      shown_on_top: false
+
+workspaces:
+  - name: "1"
+    keep_alive: true
+    bind_to_monitor: 1
+  - name: "2"
+    keep_alive: true
+    bind_to_monitor: 1
+    display_name: "wsl"
+  - name: "3"
+    keep_alive: true
+    bind_to_monitor: 0
+    display_name: "zen"
+  - name: "4"
+    keep_alive: true
+    bind_to_monitor: 1
+    display_name: "obs"
+  - name: "5"
+  - name: "6"
+  - name: "7"
+    display_name: "coms"
+
+  - name: "8"
+  - name: "9"
+    display_name: ""
+    keep_alive: false
+    bind_to_monitor: 1
+
+window_rules:
+  - commands: ["move --workspace 1"]
+    match:
+      - window_title: { regex: "^1[Pp]assword" }
+      - window_title: { regex: "[Zz]otero" }
+      - window_title: { regex: "^[Cc]laude$" }
+  - commands: ["move --workspace 2", "focus --workspace 2"]
+    match:
+      - window_title: { regex: "wsl" }
+  - commands: ["move --workspace 3", "focus --workspace 3"]
+    match:
+      - window_process: { equals: "zen" }
+
+  - commands: ["set-tiling"]
+    match:
+      - window_process: { equals: "zen" }
+
+  - commands: ["move --workspace 4", "focus --workspace 4"]
+    match:
+      - window_process: { regex: "^[Oo]bsidian" }
+
+  - commands: ["move --workspace 7"]
+    match:
+      - window_title: { regex: "[Tt]hunderbird" }
+      - window_title: { regex: "^[Ww]hats[Aa]pp$" }
+
+  - commands: ["move --workspace 9", "focus --workspace 9"]
+    match:
+      - window_title: { equals: "Task Manager" }
+
+  - commands: ["ignore"]
+    match:
+      # Ignores any Zebar windows.
+      - window_process: { equals: "zebar" }
+
+      # Ignores picture-in-picture windows for browsers.
+      - window_title: { regex: "[Pp]icture.in.[Pp]icture" }
+        window_class: { regex: "Chrome_WidgetWin_1|MozillaDialogClass" }
+
+      # Ignore rules for various 3rd-party apps.
+      - window_process: { equals: "PowerToys" }
+        window_class: { regex: 'HwndWrapper\[PowerToys\.PowerAccent.*?\]' }
+      - window_process: { equals: "PowerToys" }
+        window_title: { regex: ".*? - Peek" }
+      - window_title: { regex: ".*Command Palette.*" }
+      - window_process: { equals: "Lively" }
+        window_class: { regex: "HwndWrapper" }
+
+      # Ignore windows started from wsl (linux)
+      - window_title: { regex: "Ubuntu" }
+
+      # Ignore login screen
+      - window_title: { regex: "Enter your username and password" }
+
+binding_modes:
+  # When enabled, the focused window can be resized via arrow keys or HJKL.
+  - name: "resize"
+    keybindings:
+      - commands: ["resize --width -2%"]
+        bindings: ["h", "left"]
+      - commands: ["resize --width +2%"]
+        bindings: ["l", "right"]
+      - commands: ["resize --height +2%"]
+        bindings: ["k", "up"]
+      - commands: ["resize --height -2%"]
+        bindings: ["j", "down"]
+      # Press enter/escape to return to default keybindings.
+      - commands: ["wm-disable-binding-mode --name resize"]
+        bindings: ["escape", "enter", "alt+r"]
+
+keybindings:
+  # Shift focus in a given direction.
+  - commands: ["focus --direction left"]
+    bindings: ["alt+h"]
+  - commands: ["focus --direction right"]
+    bindings: ["alt+l"]
+  - commands: ["focus --direction up"]
+    bindings: ["alt+k"]
+  - commands: ["focus --direction down"]
+    bindings: ["alt+j"]
+
+  # Move focused window in a given direction.
+  - commands: ["move --direction left"]
+    bindings: ["alt+shift+h"]
+  - commands: ["move --direction right"]
+    bindings: ["alt+shift+l"]
+  - commands: ["move --direction up"]
+    bindings: ["alt+shift+k"]
+  - commands: ["move --direction down"]
+    bindings: ["alt+shift+j"]
+
+  # Resize focused window by a percentage or pixel amount.
+  - commands: ["resize --width -2%"]
+    bindings: ["alt+u"]
+  - commands: ["resize --width +2%"]
+    bindings: ["alt+p"]
+  - commands: ["resize --height +2%"]
+    bindings: ["alt+o"]
+  - commands: ["resize --height -2%"]
+    bindings: ["alt+i"]
+
+  # As an alternative to the resize keybindings above, resize mode enables
+  # resizing via arrow keys or HJKL. The binding mode is defined above with
+  # the name 'resize'.
+  - commands: ["wm-enable-binding-mode --name resize"]
+    bindings: ["alt+r"]
+
+  # Disables window management and all other keybindings until alt+shift+p
+  # is pressed again.
+  - commands: ["wm-toggle-pause"]
+    bindings: ["alt+shift+p"]
+
+  # Change tiling direction. This determines where new tiling windows will
+  # be inserted.
+  - commands: ["toggle-tiling-direction"]
+    bindings: ["alt+v"]
+
+  # Change focus from tiling windows -> floating -> fullscreen.
+  - commands: ["wm-cycle-focus"]
+    bindings: ["alt+space"]
+
+  # Change the focused window to be floating.
+  - commands: ["toggle-floating --centered"]
+    bindings: ["alt+shift+space"]
+
+  # Change the focused window to be tiling.
+  - commands: ["toggle-tiling"]
+    bindings: ["alt+t"]
+
+  # Change the focused window to be fullscreen.
+  - commands: ["toggle-fullscreen"]
+    bindings: ["alt+f"]
+
+  # Minimize focused window.
+  - commands: ["toggle-minimized"]
+    bindings: ["alt+m"]
+
+  # Close focused window.
+  - commands: ["close"]
+    bindings: ["alt+q"]
+
+  # Kill GlazeWM process safely.
+  - commands: ["wm-exit"]
+    bindings: ["alt+shift+e"]
+
+  # Re-evaluate configuration file.
+  - commands: ["wm-reload-config"]
+    bindings: ["alt+shift+r"]
+
+  # Redraw all windows.
+  - commands: ["wm-redraw"]
+    bindings: ["alt+shift+w"]
+
+  # Recovery: restart GlazeWM so it re-enumerates every top-level window and
+  # re-adopts any it lost track of (e.g. Zen after sleep/wake or a profile
+  # switch). Relaunch runs in a detached shell so it survives the kill.
+  - commands:
+      [
+        "shell-exec powershell -NoProfile -Command Start-Sleep -Milliseconds 800; Start-Process glazewm",
+        "wm-exit",
+      ]
+    bindings: ["alt+shift+x"]
+
+  # Launch CMD terminal. Alternatively, use `shell-exec wt` or
+  # `shell-exec %ProgramFiles%/Git/git-bash.exe` to start Windows
+  # Terminal and Git Bash respectively.
+  - commands: ["shell-exec wt"]
+    bindings: ["alt+enter"]
+  - commands: ["shell-exec zen"]
+    bindings: ["alt+z"]
+
+  # Focus the workspace that last had focus.
+  - commands: ["focus --recent-workspace"]
+    bindings: ["alt+d"]
+
+  # Change focus to a workspace defined in `workspaces` config.
+  - commands: ["focus --workspace 1"]
+    bindings: ["alt+1"]
+  - commands: ["focus --workspace 2"]
+    bindings: ["alt+2"]
+  - commands: ["focus --workspace 3"]
+    bindings: ["alt+3"]
+  - commands: ["focus --workspace 4"]
+    bindings: ["alt+4"]
+  - commands: ["focus --workspace 5"]
+    bindings: ["alt+5"]
+  - commands: ["focus --workspace 6"]
+    bindings: ["alt+6"]
+  - commands: ["focus --workspace 7"]
+    bindings: ["alt+7"]
+  - commands: ["focus --workspace 8"]
+    bindings: ["alt+8"]
+  - commands: ["focus --workspace 9"]
+    bindings: ["alt+9"]
+
+  # Move the focused window's parent workspace to a monitor in a given
+  # direction.
+  - commands: ["move-workspace --direction left"]
+    bindings: ["alt+shift+a"]
+  - commands: ["move-workspace --direction right"]
+    bindings: ["alt+shift+f"]
+  - commands: ["move-workspace --direction up"]
+    bindings: ["alt+shift+d"]
+  - commands: ["move-workspace --direction down"]
+    bindings: ["alt+shift+s"]
+
+  # Move focused window to a workspace defined in `workspaces` config.
+  - commands: ["move --workspace 1", "focus --workspace 1"]
+    bindings: ["alt+shift+1"]
+  - commands: ["move --workspace 2", "focus --workspace 2"]
+    bindings: ["alt+shift+2"]
+  - commands: ["move --workspace 3", "focus --workspace 3"]
+    bindings: ["alt+shift+3"]
+  - commands: ["move --workspace 4", "focus --workspace 4"]
+    bindings: ["alt+shift+4"]
+  - commands: ["move --workspace 5", "focus --workspace 5"]
+    bindings: ["alt+shift+5"]
+  - commands: ["move --workspace 6", "focus --workspace 6"]
+    bindings: ["alt+shift+6"]
+  - commands: ["move --workspace 7", "focus --workspace 7"]
+    bindings: ["alt+shift+7"]
+  - commands: ["move --workspace 8", "focus --workspace 8"]
+    bindings: ["alt+shift+8"]
+  - commands: ["move --workspace 9", "focus --workspace 9"]
+    bindings: ["alt+shift+9"]
+  - commands: ["set-tiling"]
+    bindings: ["alt+shift+t"]


### PR DESCRIPTION
## What
Adds my GlazeWM config (`~/.glzr/glazewm/config.yaml`) to the dotfiles — the first Windows-only config in the repo.

## Details
- Stored as `home/dot_glzr/glazewm/config.yaml` (chezmoi source naming for `~/.glzr/glazewm/config.yaml`).
- Adds `home/.chezmoiignore` gating `.glzr` to Windows only, so `chezmoi apply` won't create a stray `~/.glzr` on Linux/WSL machines:
  ```
  {{ if ne .chezmoi.os "windows" }}
  .glzr
  {{ end }}
  ```
- Plain file (not a `.tmpl`) — the config has no secrets or templated values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)