### PR TITLE
Add xdg-utils to package installation list

### DIFF
--- a/home/.chezmoiscripts/run_onchange_before_install_packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_install_packages.sh.tmpl
@@ -15,6 +15,7 @@
   "tar"
   "units"
   "unzip"
+  "xdg-utils"
   "zsh"
   "gh" -}}
 


### PR DESCRIPTION
## Summary
Adds `xdg-utils` to the list of packages installed during system setup.

## Changes
- Added `xdg-utils` to the package list in `home/.chezmoiscripts/run_onchange_before_install_packages.sh.tmpl`

## Details
`xdg-utils` provides command-line tools for interacting with the XDG (X Desktop Group) standards, including utilities like `xdg-open` for opening files/URLs with default applications. This is a common dependency for CLI tools that need to launch external applications or open files in the user's preferred handler.

https://claude.ai/code/session_01D12rgg78r2NkDkW8Y6iqb8